### PR TITLE
AUT-1705: Add Sonar to SDK react-native-client.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up nodejs
         uses: actions/setup-node@v2
@@ -29,7 +31,48 @@ jobs:
         run: npm run check
 
       - name: npm Test
-        run: npm run test
+        run: npm run test -- --coverage
 
       - name: npm Build
         run: npm run build
+
+      - name: SonarQube Scan (Push)
+        if: github.event_name == 'push'
+        uses: SonarSource/sonarcloud-github-action@v1.6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+            -Dsonar.exclusions=**/*.java
+            -Dsonar.c.file.suffixes=-
+            -Dsonar.cpp.file.suffixes=-
+            -Dsonar.objc.file.suffixes=-
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+
+      - name: SonarQube Scan (Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: SonarSource/sonarcloud-github-action@v1.6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+            -Dsonar.exclusions=**/*.java
+            -Dsonar.c.file.suffixes=-
+            -Dsonar.cpp.file.suffixes=-
+            -Dsonar.objc.file.suffixes=-
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up nodejs
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.16.0'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
 
       - name: SonarQube Scan (Push)
         if: github.event_name == 'push'
-        uses: SonarSource/sonarcloud-github-action@v1.6
+        uses: SonarSource/sonarcloud-github-action@v1.8
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         with:
@@ -57,7 +57,7 @@ jobs:
 
       - name: SonarQube Scan (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: SonarSource/sonarcloud-github-action@v1.6
+        uses: SonarSource/sonarcloud-github-action@v1.8
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         with:


### PR DESCRIPTION
# React Native SDK

## What did you accomplish?
Adding SonarQube step to CI in order have a check for code quality

Since main and development are two permanent branches, we are having two executions in order to make sonar to know about the parent branch.

## How do we test the changes introduced in this PR?
Testing from this PR if the step is being executed and giving the right output.

From SonarQube site this PR is being analyzed and showing code coverage.
https://sonarqube.split-internal.com/dashboard?id=react-native-client&pullRequest=41

<img width="1596" alt="Screen Shot 2022-12-14 at 13 43 15" src="https://user-images.githubusercontent.com/45567713/207655930-6a1dc7b4-86c2-446d-bfa1-eacbb9f84516.png">

Enabled decoration for PR:
<img width="1027" alt="Screen Shot 2022-12-14 at 13 56 28" src="https://user-images.githubusercontent.com/45567713/207658782-943f2f36-3510-40d3-a1dd-7cd668e93d8a.png">


## Extra Notes
Java & iOS files were excluded from the analysis.

In order to get the blame information to SonarQube, we told GitHubActions to clone the entire history. This was done on this section: 
```
      - name: Checkout code
        uses: actions/checkout@v3
        with:
          fetch-depth: 0
```

From SonarQube site Cristian applied the following changes: 
- Renamed main branch to main since by default SonarQube uses master as main branch.
- Enabled PullRequest decoration