### PR TITLE
[Breaking change] Remove `LocalhostFromObject` export

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@
  - Added `factory.destroy()` method, which invokes the `destroy` method of all clients created by the factory.
  - Updated @splitsoftware/splitio-commons package to version 2.0.0 that includes major updates and updated some transitive dependencies for vulnerability fixes.
  - BREAKING CHANGES:
-    - @TODO Dropped support for Split Proxy v?.
+    - Removed the `LocalhostFromObject` export from the default import (`import { LocalhostFromObject } from '@splitsoftware/splitio-react-native'`). It is no longer necessary to manually import and configure it in the `sync.localhostMode` option to enable localhost mode.
 
 0.10.0 (September 13, 2024)
  - Updated @splitsoftware/splitio-commons package to version 1.17.0 that includes minor updates:

--- a/full/package.json
+++ b/full/package.json
@@ -1,7 +1,0 @@
-{
-  "main": "../lib/commonjs/full/index.js",
-  "module": "../lib/module/full/index.js",
-  "types": "../types/full/index.d.ts",
-  "react-native": "../lib/module/full/index.js",
-  "sideEffects": false
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "2.0.0-rc.0"
+        "@splitsoftware/splitio-commons": "2.0.0-rc.3"
       },
       "devDependencies": {
         "@react-native-community/eslint-config": "^2.0.0",
@@ -4739,9 +4739,9 @@
       }
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.0.tgz",
-      "integrity": "sha512-iNuGugPMXQ/+k+uSDyhsvwkaGdzQrRaxRtP1sv58STKQFwww1smPxRA1gKfawoQm04quEHtLMKYm25t6VL0fJw==",
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.3.tgz",
+      "integrity": "sha512-XkDbULWBg6nw061b4Vc425JyrpDe5nSypoScO4eVsFbgcCqUPlGbr+s9bfriwNFyZe2Q29ijIlyGM06TCt27kQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -20822,9 +20822,9 @@
       }
     },
     "@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.0.tgz",
-      "integrity": "sha512-iNuGugPMXQ/+k+uSDyhsvwkaGdzQrRaxRtP1sv58STKQFwww1smPxRA1gKfawoQm04quEHtLMKYm25t6VL0fJw==",
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.3.tgz",
+      "integrity": "sha512-XkDbULWBg6nw061b4Vc425JyrpDe5nSypoScO4eVsFbgcCqUPlGbr+s9bfriwNFyZe2Q29ijIlyGM06TCt27kQ==",
       "requires": {
         "tslib": "^2.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "homepage": "https://github.com/splitio/react-native-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "2.0.0-rc.0"
+    "@splitsoftware/splitio-commons": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^2.0.0",

--- a/src/full/splitFactory.ts
+++ b/src/full/splitFactory.ts
@@ -6,7 +6,6 @@ import { IReactNativeSettings } from '../../types/splitio';
 
 /**
  * SplitFactory for React Native.
- * Includes localhost mode.
  *
  * @param config           Configuration object used to instantiate the SDK
  * @param __updateModules  Optional function that lets redefine internal SDK modules. Use with

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,3 @@ export { ErrorLogger } from '@splitsoftware/splitio-commons/src/logger/browser/E
 export { WarnLogger } from '@splitsoftware/splitio-commons/src/logger/browser/WarnLogger';
 export { InfoLogger } from '@splitsoftware/splitio-commons/src/logger/browser/InfoLogger';
 export { DebugLogger } from '@splitsoftware/splitio-commons/src/logger/browser/DebugLogger';
-export { LocalhostFromObject } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromObject';

--- a/src/platform/getModules.ts
+++ b/src/platform/getModules.ts
@@ -6,12 +6,12 @@ import { sdkManagerFactory } from '@splitsoftware/splitio-commons/src/sdkManager
 import { sdkClientMethodCSFactory } from '@splitsoftware/splitio-commons/src/sdkClient/sdkClientMethodCS';
 import { impressionObserverCSFactory } from '@splitsoftware/splitio-commons/src/trackers/impressionObserver/impressionObserverCS';
 import { EventEmitter } from '@splitsoftware/splitio-commons/src/utils/MinEvents';
-
 import { ISdkFactoryParams } from '@splitsoftware/splitio-commons/src/sdkFactory/types';
 import { ISettings } from '@splitsoftware/splitio-commons/src/types';
 import { LOCALHOST_MODE } from '@splitsoftware/splitio-commons/src/utils/constants';
 import { createUserConsentAPI } from '@splitsoftware/splitio-commons/src/consent/sdkUserConsent';
 import { now } from '@splitsoftware/splitio-commons/src/utils/timeTracker/now/browser';
+import { localhostFromObjectFactory } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromObject';
 
 import { RNSignalListener } from './RNSignalListener';
 import { getEventSource } from './getEventSource';
@@ -57,7 +57,7 @@ export function getModules(settings: ISettings): ISdkFactoryParams {
 
   if (settings.mode === LOCALHOST_MODE) {
     modules.splitApiFactory = undefined;
-    modules.syncManagerFactory = settings.sync.localhostMode;
+    modules.syncManagerFactory = localhostFromObjectFactory;
     modules.SignalListener = undefined;
   }
 

--- a/src/settings/full.ts
+++ b/src/settings/full.ts
@@ -4,7 +4,6 @@ import { validateRuntime } from '@splitsoftware/splitio-commons/src/utils/settin
 import { validateStorageCS } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/storage/storageCS';
 import { validatePluggableIntegrations } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/integrations/pluggable';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/pluggableLogger';
-import { validateLocalhostWithDefault } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/localhost/builtin';
 import { validateConsent } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/consent';
 
 const params = {
@@ -14,7 +13,6 @@ const params = {
   storage: validateStorageCS,
   integrations: validatePluggableIntegrations,
   logger: validateLogger,
-  localhost: validateLocalhostWithDefault, // Full SplitFactory provides a default localhost module, except a valid one is provided
   consent: validateConsent,
 };
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -4,7 +4,6 @@ import { validateRuntime } from '@splitsoftware/splitio-commons/src/utils/settin
 import { validateStorageCS } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/storage/storageCS';
 import { validatePluggableIntegrations } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/integrations/pluggable';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/pluggableLogger';
-import { validateLocalhost } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/localhost/pluggable';
 import { validateConsent } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/consent';
 
 const params = {
@@ -14,7 +13,6 @@ const params = {
   storage: validateStorageCS,
   integrations: validatePluggableIntegrations,
   logger: validateLogger,
-  localhost: validateLocalhost, // Slim SplitFactory validates that the localhost module is passed in localhost mode
   consent: validateConsent,
 };
 

--- a/src/splitFactory.ts
+++ b/src/splitFactory.ts
@@ -5,8 +5,7 @@ import type { ISdkFactoryParams } from '@splitsoftware/splitio-commons/src/sdkFa
 import { IReactNativeSettings } from '../types/splitio';
 
 /**
- * Slim SplitFactory for React Native.
- * Doesn't include localhost mode out-of-the-box.
+ * SplitFactory for React Native.
  *
  * @param config           Configuration object used to instantiate the SDK
  * @param __updateModules  Optional function that lets redefine internal SDK modules. Use with

--- a/types/full/index.d.ts
+++ b/types/full/index.d.ts
@@ -7,9 +7,7 @@ export = JsSdk;
 
 declare module JsSdk {
   /**
-   * Full version of the Split.io SDK factory function.
-   *
-   * Unlike the slim version, it does include localhost mode out-of-the-box @see {@link https://help.split.io/hc/en-us/articles/4406066357901#localhost-mode}.
+   * Split.io SDK factory function.
    *
    * The settings parameter should be an object that complies with the SplitIO.IReactNativeSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/4406066357901#configuration}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,10 +7,7 @@ export = JsSdk;
 
 declare module JsSdk {
   /**
-   * Slim version of the Split.io SDK factory function.
-   *
-   * Recommended to use for bundle size reduction in production, since it doesn't include localhost mode out-of-the-box
-   * @see {@link https://help.split.io/hc/en-us/articles/4406066357901#localhost-mode}.
+   * Split.io SDK factory function.
    *
    * The settings parameter should be an object that complies with the SplitIO.IReactNativeSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/4406066357901#configuration}
@@ -44,12 +41,4 @@ declare module JsSdk {
    * @see {@link https://help.split.io/hc/en-us/articles/4406066357901#logging}
    */
   export function ErrorLogger(): SplitIO.ILogger;
-
-  /**
-   * Required to enable localhost mode when importing the SDK from the slim entry point of the library.
-   * It uses the mocked features map defined in the 'features' config object.
-   *
-   * @see {@link https://help.split.io/hc/en-us/articles/4406066357901#localhost-mode}
-   */
-  export function LocalhostFromObject(): SplitIO.LocalhostFactory;
 }

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -85,7 +85,6 @@ interface ISettings {
     impressionsMode: SplitIO.ImpressionsMode,
     enabled: boolean,
     flagSpecVersion: string,
-    localhostMode?: SplitIO.LocalhostFactory,
     requestOptions?: {
       getHeaderOverrides?: (context: { headers: Record<string, string> }) => Record<string, string>
     },
@@ -218,25 +217,6 @@ interface ISharedSettings {
      * @default 'OPTIMIZED'
      */
     impressionsMode?: SplitIO.ImpressionsMode,
-    /**
-     * Defines the factory function to instantiate the SDK in localhost mode.
-     *
-     * NOTE: this is only required if using the slim entry point of the library to init the SDK in localhost mode.
-     *
-     * For more information see {@link https://help.split.io/hc/en-us/articles/4406066357901#localhost-mode}
-     *
-     * Example:
-     * ```typescript
-     * SplitFactory({
-     *   ...
-     *   sync: {
-     *     localhostMode: LocalhostFromObject()
-     *   }
-     * })
-     * ```
-     * @property {Object} localhostMode
-     */
-    localhostMode?: SplitIO.LocalhostFactory,
     /**
      * Controls the SDK continuous synchronization flags.
      *
@@ -456,11 +436,6 @@ declare namespace SplitIO {
     [featureName: string]: string | TreatmentWithConfig
   };
   /**
-   * Localhost types.
-   * @typedef {string} LocalhostType
-   */
-  type LocalhostType = 'LocalhostFromObject'
-  /**
    * Object with information about an impression. It contains the generated impression DTO as well as
    * complementary information around where and how it was generated in that way.
    * @typedef {Object} ImpressionData
@@ -567,14 +542,6 @@ declare namespace SplitIO {
   type StorageSyncFactory = {
     readonly type: StorageType
     (params: {}): (StorageSync | undefined)
-  }
-  /**
-   * Localhost mode factory.
-   * Its interface details are not part of the public API.
-   */
-  type LocalhostFactory = {
-    readonly type: LocalhostType
-    (params: {}): {}
   }
   /**
    * Impression listener interface. This is the interface that needs to be implemented


### PR DESCRIPTION
# React Native SDK

## What did you accomplish?

Since the last refactors, the `LocalhostFromObject` module doesn't significantly impact bundle size (1KB approx), so it's included by default to favor usability.

## How do we test the changes introduced in this PR?

## Extra Notes